### PR TITLE
Depth check prepass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+sudo: false
+go:
+    - 1.7.x  # go testing suite support, which we use, was introduced in go 1.7
+    - 1.8.x
+    - 1.9.x
+    - 1.10.x
+    - tip
+script:
+    - go test -tags "alltests" -run Suite -coverprofile coverage.txt github.com/keybase/go-jsonw
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/jsonw.go
+++ b/jsonw.go
@@ -19,6 +19,16 @@ type Error struct {
 	msg string
 }
 
+type DepthError struct {
+	msg string
+}
+
+func (d DepthError) Error() string {
+	return fmt.Sprintf("DepthError: %s", d.msg)
+}
+
+const defaultMaxDepth int = 50
+
 func (w *Wrapper) Marshal() ([]byte, error) {
 	return json.Marshal(w.dat)
 }
@@ -41,11 +51,20 @@ func (w *Wrapper) MarshalToDebug() string {
 	}
 }
 
-func Unmarshal(raw []byte) (*Wrapper, error) {
+func Unmarshal(unsafeRaw []byte) (*Wrapper, error) {
+	return UnmarshalWithMaxDepth(unsafeRaw, defaultMaxDepth)
+}
+
+func UnmarshalWithMaxDepth(unsafeRaw []byte, maxDepth int) (*Wrapper, error) {
+	raw, err := ensureMaxDepth(unsafeRaw, maxDepth)
+	if err != nil {
+		return nil, err
+	}
+
 	var iface interface{}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.UseNumber()
-	err := dec.Decode(&iface)
+	err = dec.Decode(&iface)
 	var ret *Wrapper
 	if err == nil {
 		ret = NewWrapper(iface)
@@ -680,4 +699,55 @@ func (w *Wrapper) AssertEqAtPath(path string, obj *Wrapper, errp *error) {
 			path, string(b1), string(b2))
 	}
 	return
+}
+
+const JSONEscape = 0x5c
+const JSONDoubleQuotationMark = 0x22
+const JSONLeftSquareBracket = 0x5b
+const JSONLeftCurlyBracket = 0x7b
+const JSONRightSquareBracket = 0x5d
+const JSONRightCurlyBracket = 0x7d
+
+// ensureMaxDepth returns an error if raw represents a valid JSON string whose
+// deserialization's maximum depth exceeds maxDepth.
+// If raw represents an invalid JSON string with a prefix that is a valid JSON prefix
+// whose depth exceeds maxDepth, an error will be returned as well).
+// See https://github.com/golang/go/blob/master/src/encoding/json/decode.go#L96.
+// Otherwise, behavior is undefined and an error may or may not be returned.
+// See the spec at https://json.org.
+func ensureMaxDepth(unsafeRaw []byte, maxDepth int) ([]byte, error) {
+	depth := 1
+	inString := false
+	lastByteWasEscape := false
+	for _, b := range unsafeRaw {
+		if depth >= maxDepth {
+			return []byte{}, DepthError{fmt.Sprintf("Invalid JSON or exceeds max depth %d.", maxDepth)}
+		}
+		if inString {
+			if lastByteWasEscape {
+				// i.e., if the last byte was an escape, we are no longer in an
+				// escape sequence. This is not strictly true: JSON unicode codepoint
+				// escape sequences are of the form \uXXXX where X is a hexadecimal
+				// character. However since X cannot be JSONEscape or JSONDoubleQuotationMark
+				// in valid JSON, there is no problem: later there will be an
+				// error parsing the JSON and this will occur before maxDepth
+				// is reached in the JSON parser.
+				lastByteWasEscape = false
+			} else if b == JSONEscape {
+				lastByteWasEscape = true
+			} else if b == JSONDoubleQuotationMark {
+				inString = false
+			}
+		} else {
+			switch b {
+			case JSONDoubleQuotationMark:
+				inString = true
+			case JSONLeftSquareBracket, JSONLeftCurlyBracket:
+				depth += 1
+			case JSONRightSquareBracket, JSONRightCurlyBracket:
+				depth -= 1
+			}
+		}
+	}
+	return unsafeRaw, nil
 }

--- a/jsonw.go
+++ b/jsonw.go
@@ -701,12 +701,12 @@ func (w *Wrapper) AssertEqAtPath(path string, obj *Wrapper, errp *error) {
 	return
 }
 
-const JSONEscape = 0x5c
-const JSONDoubleQuotationMark = 0x22
-const JSONLeftSquareBracket = 0x5b
-const JSONLeftCurlyBracket = 0x7b
-const JSONRightSquareBracket = 0x5d
-const JSONRightCurlyBracket = 0x7d
+const JSONEscape = byte('\\')
+const JSONDoubleQuotationMark = byte('"')
+const JSONLeftSquareBracket = byte('[')
+const JSONLeftCurlyBracket = byte('{')
+const JSONRightSquareBracket = byte(']')
+const JSONRightCurlyBracket = byte('}')
 
 // ensureMaxDepth returns an error if raw represents a valid JSON string whose
 // deserialization's maximum depth exceeds maxDepth.


### PR DESCRIPTION
Security logic is kind of confusing. But it's hard to reason about invalid JSON without actually parsing it (which is what we're trying to avoid). Here, if there will be recursion > maxDepth, there will either be a DepthError or a json.SyntaxError later before that happens.

libkb tests pass after vendoring in.